### PR TITLE
fix(provider): Handle resource not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=github.com
 NAMESPACE=komodorio
 NAME=komodor
 BINARY=terraform-provider-${NAME}
-VERSION=1.0.6
+VERSION=1.0.7
 OS_ARCH=darwin_amd64
 
 default: install

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Clone the repository:
 
 ```sh
 mkdir -p $GOPATH/src/github.com/terraform-providers; cd "$_"
-git clone https://github.com/komodor/terraform-provider-komodor.git
+git clone https://github.com/komodorio/terraform-provider-komodor.git
 ```
 
 Change to the clone directory and run make to install the dependent tooling needed to test and build the provider.

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     komodor = {
-      version = "1.0.4"
+      version = ">= 1.0.6"
       source  = "komodorio/komodor"
     }
   }

--- a/komodor/client.go
+++ b/komodor/client.go
@@ -36,7 +36,7 @@ func (c *Client) executeHttpRequest(method string, url string, body *[]byte) ([]
 	req.Header.Set("Content-Type", "application/json")
 	res, err := c.HttpClient.Do(req)
 	if err != nil {
-		return nil, 0, err
+		return nil, res.StatusCode, err
 	}
 	defer res.Body.Close()
 	resBody, err := io.ReadAll(res.Body)

--- a/komodor/client.go
+++ b/komodor/client.go
@@ -23,29 +23,29 @@ func NewClient(apiKey string) *Client {
 	}
 }
 
-func (c *Client) executeHttpRequest(method string, url string, body *[]byte) ([]byte, error) {
+func (c *Client) executeHttpRequest(method string, url string, body *[]byte) ([]byte, int, error) {
 	var reader io.Reader
 	if body != nil {
 		reader = bytes.NewReader(*body)
 	}
 	req, err := http.NewRequest(method, url, reader)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	req.Header.Set("x-api-key", c.ApiKey)
 	req.Header.Set("Content-Type", "application/json")
 	res, err := c.HttpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer res.Body.Close()
 	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, err
+		return nil, res.StatusCode, err
 	}
 	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusCreated || res.StatusCode == http.StatusNoContent {
-		return resBody, nil
+		return resBody, res.StatusCode, nil
 	} else {
-		return nil, fmt.Errorf("%d %s", res.StatusCode, resBody)
+		return resBody, res.StatusCode, fmt.Errorf("%d %s", res.StatusCode, resBody)
 	}
 }

--- a/komodor/monitors.go
+++ b/komodor/monitors.go
@@ -80,7 +80,7 @@ type Monitor struct {
 }
 
 func (c *Client) GetMonitors() ([]Monitor, error) {
-	res, err := c.executeHttpRequest(http.MethodGet, MonitorsUrl, nil)
+	res, _, err := c.executeHttpRequest(http.MethodGet, MonitorsUrl, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -95,18 +95,18 @@ func (c *Client) GetMonitors() ([]Monitor, error) {
 	return monitors, nil
 }
 
-func (c *Client) GetMonitor(id string) (*Monitor, error) {
-	res, err := c.executeHttpRequest(http.MethodGet, fmt.Sprintf(MonitorsUrl+"/%s", id), nil)
+func (c *Client) GetMonitor(id string) (*Monitor, int, error) {
+	res, statusCode, err := c.executeHttpRequest(http.MethodGet, fmt.Sprintf(MonitorsUrl+"/%s", id), nil)
 	if err != nil {
-		return nil, err
+		return nil, statusCode, err
 	}
 	var monitor Monitor
 	err = json.Unmarshal(res, &monitor)
 	if err != nil {
-		return nil, err
+		return nil, statusCode, err
 	}
 
-	return &monitor, nil
+	return &monitor, statusCode, nil
 }
 
 func (c *Client) UpdateMonitor(id string, m *NewMonitor) ([]byte, error) {
@@ -114,7 +114,7 @@ func (c *Client) UpdateMonitor(id string, m *NewMonitor) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	res, err := c.executeHttpRequest(http.MethodPut, fmt.Sprintf(MonitorsUrl+"/%s", id), &jsonMonitor)
+	res, _, err := c.executeHttpRequest(http.MethodPut, fmt.Sprintf(MonitorsUrl+"/%s", id), &jsonMonitor)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (c *Client) CreateMonitor(m *NewMonitor) (*Monitor, error) {
 	if err != nil {
 		return nil, err
 	}
-	res, err := c.executeHttpRequest(http.MethodPost, MonitorsUrl, &jsonMonitor)
+	res, _, err := c.executeHttpRequest(http.MethodPost, MonitorsUrl, &jsonMonitor)
 
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ func (c *Client) CreateMonitor(m *NewMonitor) (*Monitor, error) {
 
 func (c *Client) DeleteMonitor(id string) error {
 	requestUrl := strings.Join([]string{MonitorsUrl, "/", id}, "")
-	_, err := c.executeHttpRequest(http.MethodDelete, requestUrl, nil)
+	_, _, err := c.executeHttpRequest(http.MethodDelete, requestUrl, nil)
 	if err != nil {
 		return err
 	}

--- a/komodor/policies.go
+++ b/komodor/policies.go
@@ -32,7 +32,7 @@ type NewPolicy struct {
 }
 
 func (c *Client) GetPolicies() ([]Policy, error) {
-	res, err := c.executeHttpRequest(http.MethodGet, PoliciesUrl, nil)
+	res, _, err := c.executeHttpRequest(http.MethodGet, PoliciesUrl, nil)
 
 	if err != nil {
 		return nil, err
@@ -48,21 +48,21 @@ func (c *Client) GetPolicies() ([]Policy, error) {
 	return policies, nil
 }
 
-func (c *Client) GetPolicy(id string) (*Policy, error) {
+func (c *Client) GetPolicy(id string) (*Policy, int, error) {
 	var policy Policy
 
-	res, err := c.executeHttpRequest(http.MethodGet, fmt.Sprintf(PoliciesUrl+"/%s", id), nil)
+	res, statusCode, err := c.executeHttpRequest(http.MethodGet, fmt.Sprintf(PoliciesUrl+"/%s", id), nil)
 
 	if err != nil {
-		return nil, err
+		return nil, statusCode, err
 	}
 
 	err = json.Unmarshal(res, &policy)
 	if err != nil {
-		return nil, err
+		return nil, statusCode, err
 	}
 
-	return &policy, nil
+	return &policy, statusCode, nil
 }
 
 func (c *Client) GetPolicyByName(name string) (*Policy, error) {
@@ -87,7 +87,7 @@ func (c *Client) CreatePolicy(p *NewPolicy) (*Policy, error) {
 	if err != nil {
 		return nil, err
 	}
-	res, err := c.executeHttpRequest(http.MethodPost, PoliciesUrl, &jsonPolicy)
+	res, _, err := c.executeHttpRequest(http.MethodPost, PoliciesUrl, &jsonPolicy)
 
 	if err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ func (c *Client) DeletePolicy(id string) error {
 	if err != nil {
 		return err
 	}
-	_, err = c.executeHttpRequest(http.MethodDelete, PoliciesUrl, &requestBody)
+	_, _, err = c.executeHttpRequest(http.MethodDelete, PoliciesUrl, &requestBody)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (c *Client) UpdatePolicy(id string, p *NewPolicy) (*Policy, error) {
 	if err != nil {
 		return nil, err
 	}
-	res, err := c.executeHttpRequest(http.MethodPut, fmt.Sprintf(PoliciesUrl+"/%s", id), &jsonPolicy)
+	res, _, err := c.executeHttpRequest(http.MethodPut, fmt.Sprintf(PoliciesUrl+"/%s", id), &jsonPolicy)
 	if err != nil {
 		return nil, err
 	}

--- a/komodor/resource_komodor_monitor.go
+++ b/komodor/resource_komodor_monitor.go
@@ -117,9 +117,9 @@ func resourceKomodorMonitorRead(ctx context.Context, d *schema.ResourceData, met
 	client := meta.(*Client)
 	id := d.Id()
 
-	monitor, err := client.GetMonitor(id)
+	monitor, statusCode, err := client.GetMonitor(id)
 	if err != nil {
-		if err.Error() == "404" {
+		if statusCode == 404 {
 			log.Printf("[DEBUG] Monitor (%s) was not found - removing from state", d.Id())
 			d.SetId("")
 			return nil

--- a/komodor/resource_komodor_policy.go
+++ b/komodor/resource_komodor_policy.go
@@ -74,9 +74,9 @@ func resourceKomodorPolicyRead(ctx context.Context, d *schema.ResourceData, meta
 	client := meta.(*Client)
 	id := d.Id()
 
-	policy, err := client.GetPolicy(id)
+	policy, statusCode, err := client.GetPolicy(id)
 	if err != nil {
-		if err.Error() == "404" {
+		if statusCode == 404 {
 			log.Printf("[DEBUG] Policy (%s) was not found - removing from state", d.Id())
 			d.SetId("")
 			return nil

--- a/komodor/resource_komodor_policy_role_attachement.go
+++ b/komodor/resource_komodor_policy_role_attachement.go
@@ -59,9 +59,9 @@ func resourcePolicyRoleAttachmentRead(ctx context.Context, d *schema.ResourceDat
 	client := meta.(*Client)
 	roleId := d.Get("role").(string)
 
-	rolePolicyObject, err := client.GetRolePoliciesObject(roleId)
+	rolePolicyObject, statusCode, err := client.GetRolePoliciesObject(roleId)
 	if err != nil {
-		if err.Error() == "404" {
+		if statusCode == 404 {
 			log.Printf("[DEBUG] Role-Policy object (%s) was not found - removing from state", d.Id())
 			d.SetId("")
 			return nil

--- a/komodor/resource_komodor_role.go
+++ b/komodor/resource_komodor_role.go
@@ -67,9 +67,9 @@ func resourceKomodorRoleRead(ctx context.Context, d *schema.ResourceData, meta i
 	client := meta.(*Client)
 	id := d.Id()
 
-	role, err := client.GetRole(id)
+	role, statusCode, err := client.GetRole(id)
 	if err != nil {
-		if err.Error() == "404" {
+		if statusCode == 404 {
 			log.Printf("[DEBUG] Role (%s) was not found - removing from state", d.Id())
 			d.SetId("")
 			return nil

--- a/komodor/role_policy_attachment.go
+++ b/komodor/role_policy_attachment.go
@@ -19,7 +19,7 @@ func (c *Client) AttachPolicy(policyId string, roleId string) error {
 	if err != nil {
 		return err
 	}
-	_, err = c.executeHttpRequest(http.MethodPost, PolicyRoleAttachmentUrl, &requestBody)
+	_, _, err = c.executeHttpRequest(http.MethodPost, PolicyRoleAttachmentUrl, &requestBody)
 	if err != nil {
 		return err
 	}
@@ -27,20 +27,20 @@ func (c *Client) AttachPolicy(policyId string, roleId string) error {
 	return nil
 }
 
-func (c *Client) GetRolePoliciesObject(roleId string) ([]RolePolicy, error) {
+func (c *Client) GetRolePoliciesObject(roleId string) ([]RolePolicy, int, error) {
 	var rolePolicies []RolePolicy
 
-	res, err := c.executeHttpRequest(http.MethodGet, fmt.Sprintf(DefaultEndpoint+"/rbac/roles/%s/policies", roleId), nil)
+	res, statusCode, err := c.executeHttpRequest(http.MethodGet, fmt.Sprintf(DefaultEndpoint+"/rbac/roles/%s/policies", roleId), nil)
 	if err != nil {
-		return nil, err
+		return nil, statusCode, err
 	}
 
 	err = json.Unmarshal([]byte(res), &rolePolicies)
 	if err != nil {
-		return nil, err
+		return nil, statusCode, err
 	}
 
-	return rolePolicies, nil
+	return rolePolicies, statusCode, nil
 }
 
 func (c *Client) DetachPolicy(policyId string, roleId string) error {
@@ -49,7 +49,7 @@ func (c *Client) DetachPolicy(policyId string, roleId string) error {
 	if err != nil {
 		return err
 	}
-	_, err = c.executeHttpRequest(http.MethodDelete, PolicyRoleAttachmentUrl, &requestBody)
+	_, _, err = c.executeHttpRequest(http.MethodDelete, PolicyRoleAttachmentUrl, &requestBody)
 	if err != nil {
 		return err
 	}

--- a/komodor/roles.go
+++ b/komodor/roles.go
@@ -21,7 +21,7 @@ type NewRole struct {
 }
 
 func (c *Client) GetRoles() ([]Role, error) {
-	res, err := c.executeHttpRequest(http.MethodGet, RolesUrl, nil)
+	res, _, err := c.executeHttpRequest(http.MethodGet, RolesUrl, nil)
 
 	if err != nil {
 		return nil, err
@@ -53,21 +53,21 @@ func (c *Client) GetRoleByName(name string) (*Role, error) {
 	return targetRole, nil
 }
 
-func (c *Client) GetRole(id string) (*Role, error) {
+func (c *Client) GetRole(id string) (*Role, int, error) {
 	var role Role
 
-	res, err := c.executeHttpRequest(http.MethodGet, fmt.Sprintf(RolesUrl+"/%s", id), nil)
+	res, statusCode, err := c.executeHttpRequest(http.MethodGet, fmt.Sprintf(RolesUrl+"/%s", id), nil)
 
 	if err != nil {
-		return nil, err
+		return nil, statusCode, err
 	}
 
 	err = json.Unmarshal(res, &role)
 	if err != nil {
-		return nil, err
+		return nil, statusCode, err
 	}
 
-	return &role, nil
+	return &role, statusCode, nil
 }
 
 func (c *Client) CreateRole(role *NewRole) (*Role, error) {
@@ -76,7 +76,7 @@ func (c *Client) CreateRole(role *NewRole) (*Role, error) {
 	if err != nil {
 		return nil, err
 	}
-	res, err := c.executeHttpRequest(http.MethodPost, RolesUrl, &requestBody)
+	res, _, err := c.executeHttpRequest(http.MethodPost, RolesUrl, &requestBody)
 
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (c *Client) DeleteRole(id string) error {
 		return err
 	}
 
-	_, err = c.executeHttpRequest(http.MethodDelete, RolesUrl, &requestBody)
+	_, _, err = c.executeHttpRequest(http.MethodDelete, RolesUrl, &requestBody)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* Return the response status code and check if it is 404

Till now, we were checking if the error is a 404 error based on the error return string which contained both the error number and error text. This check was incorrect.

In this PR, the HttpResponse status code is returned to the cooler function, not just the return body and error message.