### PR TITLE
Feat: support custom k8s actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=github.com
 NAMESPACE=komodorio
 NAME=komodor
 BINARY=terraform-provider-${NAME}
-VERSION=1.0.7
+VERSION=1.0.8
 OS_ARCH=darwin_amd64
 
 default: install

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,16 +1,3 @@
-terraform {
-  required_providers {
-    komodor = {
-      version = ">= 1.0.6"
-      source  = "komodorio/komodor"
-    }
-  }
-}
-
-provider "komodor" {
-  api_key = var.api_key
-}
-
 resource "komodor_policy" "my-policy" {
   name       = "my-policy"
   statements = <<EOF
@@ -40,91 +27,6 @@ resource "komodor_policy_role_attachment" "my-attachement" {
   name     = "test-attachement"
   policies = [komodor_policy.my-policy.id]
   role     = komodor_role.my-role.id
-}
-
-resource "komodor_monitor" "example-deploy-monitor" {
-  name          = "example-deploy-monitor"
-  type          = "deploy"
-  active        = true
-  sensors       = <<EOF
-[{
-  "cluster": "kind-kind",
-  "exclude": {
-    "namespaces": ["komodor"]
-  },
-  "namespaces": [
-    "default"
-  ]
-}]
-EOF
-  sinks         = <<EOF
-{
-  "slack": [
-    "default"
-  ],
-  "teams": [
-    "default"
-  ],
-  "pagerduty": [{
-    "channel": "example-channel",
-    "integrationKey": "example-pagerduty-integration-key",
-    "pagerDutyAccountName": "example-pagerduty-account-name"
-  }]
-}
-EOF 
-  sinks_options = <<EOF
-{
-  "notifyOn": ["Failure"]
-}
-EOF 
-}
-
-resource "komodor_monitor" "example-availability-monitor" {
-  name      = "example-availability-monitor"
-  type      = "availability"
-  active    = true
-  sensors   = <<EOF
-[{
-  "cluster": "kind-kind",
-  "exclude": {
-    "services": ["default/service-to-exclude"]
-  },
-  "services": [
-    "default/service-to-include"
-  ],
-  "condition": "and",
-  "namespaces": ["default"]
-}]
-EOF
-  sinks     = <<EOF
-{
-  "slack": [
-    "default"
-  ],
-  "teams": [
-    "default"
-  ],
-  "pagerduty": [{
-    "channel": "example-channel",
-    "integrationKey": "example-pagerduty-integration-key",
-    "pagerDutyAccountName": "example-pagerduty-account-name"
-  }]
-}
-EOF  
-  variables = <<EOF
-{
-  "categories": [
-    "*"
-  ],
-  "duration": 30,
-  "minAvailable": "100%"
-}
-EOF 
-  sinks_options = <<EOF
-{
-  "notifyOn": ["*"]
-}
-EOF 
 }
 
 data "komodor_policy" "my-policy" {

--- a/examples/monitors.tf
+++ b/examples/monitors.tf
@@ -1,0 +1,84 @@
+resource "komodor_monitor" "example-deploy-monitor" {
+  name          = "example-deploy-monitor"
+  type          = "deploy"
+  active        = true
+  sensors       = <<EOF
+[{
+  "cluster": "kind-kind",
+  "exclude": {
+    "namespaces": ["komodor"]
+  },
+  "namespaces": [
+    "default"
+  ]
+}]
+EOF
+  sinks         = <<EOF
+{
+  "slack": [
+    "default"
+  ],
+  "teams": [
+    "default"
+  ],
+  "pagerduty": [{
+    "channel": "example-channel",
+    "integrationKey": "example-pagerduty-integration-key",
+    "pagerDutyAccountName": "example-pagerduty-account-name"
+  }]
+}
+EOF 
+  sinks_options = <<EOF
+{
+  "notifyOn": ["Failure"]
+}
+EOF 
+}
+
+resource "komodor_monitor" "example-availability-monitor" {
+  name      = "example-availability-monitor"
+  type      = "availability"
+  active    = true
+  sensors   = <<EOF
+[{
+  "cluster": "kind-kind",
+  "exclude": {
+    "services": ["default/service-to-exclude"]
+  },
+  "services": [
+    "default/service-to-include"
+  ],
+  "condition": "and",
+  "namespaces": ["default"]
+}]
+EOF
+  sinks     = <<EOF
+{
+  "slack": [
+    "default"
+  ],
+  "teams": [
+    "default"
+  ],
+  "pagerduty": [{
+    "channel": "example-channel",
+    "integrationKey": "example-pagerduty-integration-key",
+    "pagerDutyAccountName": "example-pagerduty-account-name"
+  }]
+}
+EOF  
+  variables = <<EOF
+{
+  "categories": [
+    "*"
+  ],
+  "duration": 30,
+  "minAvailable": "100%"
+}
+EOF 
+  sinks_options = <<EOF
+{
+  "notifyOn": ["*"]
+}
+EOF 
+}

--- a/examples/policy_with_action.tf
+++ b/examples/policy_with_action.tf
@@ -1,0 +1,38 @@
+resource "komodor_action" "komo-example-pod-viewer" {
+  action       = "pod-viewer"
+  description = "View pods"
+  ruleset = <<EOF
+[
+  {
+    "apiGroups": [
+      "apps"
+    ],
+    "resources": [
+      "pods"
+    ],
+    "verbs": [
+      "get",
+      "list"
+    ]
+  }
+]
+EOF
+}
+
+resource "komodor_policy" "komo-example-policy" {
+  name       = "komo-example-policy"
+  statements = <<EOF
+[{
+  "actions": [
+    "${komodor_action.komo-example-pod-viewer.action}"
+  ],
+  "resources": [{
+    "cluster": "komo-example-cluster",
+    "namespaces": [
+      "default",
+      "kube-system"
+    ]
+  }]
+}]
+EOF
+}

--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    komodor = {
+      version = ">= 1.0.8"
+      source  = "komodorio/komodor"
+    }
+  }
+}
+
+provider "komodor" {
+  api_key = var.api_key
+}

--- a/komodor/custom_k8s_action.go
+++ b/komodor/custom_k8s_action.go
@@ -1,0 +1,110 @@
+package komodor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const CustomK8sActionUrl string = DefaultEndpoint + "/rbac/actions"
+
+type CustomK8sActionStatement struct {
+	ApiGroups []string `json:"apiGroups"`
+	Resources []string `json:"resources"`
+	Verbs     []string `json:"verbs"`
+}
+
+type CustomK8sAction struct {
+	Id          string                     `json:"id"`
+	Action      string                     `json:"action"`
+	Description string                     `json:"description"`
+	Ruleset     []CustomK8sActionStatement `json:"k8sRuleset"`
+	CreatedAt   string                     `json:"createdAt"`
+	UpdatedAt   string                     `json:"updatedAt"`
+}
+
+type NewCustomK8sAction struct {
+	Action      string                     `json:"action"`
+	Description string                     `json:"description"`
+	Ruleset     []CustomK8sActionStatement `json:"k8sRuleset"`
+}
+
+func (c *Client) GetCustomK8sActions() ([]CustomK8sAction, error) {
+	res, _, err := c.executeHttpRequest(http.MethodGet, CustomK8sActionUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var customK8sActions []CustomK8sAction
+
+	err = json.Unmarshal(res, &customK8sActions)
+	if err != nil {
+		return nil, err
+	}
+
+	return customK8sActions, nil
+}
+
+func (c *Client) GetCustomK8sAction(id string) (*CustomK8sAction, int, error) {
+	var customK8sAction CustomK8sAction
+
+	res, statusCode, err := c.executeHttpRequest(http.MethodGet, fmt.Sprintf(CustomK8sActionUrl+"/%s", id), nil)
+	if err != nil {
+		return nil, statusCode, err
+	}
+
+	err = json.Unmarshal(res, &customK8sAction)
+	if err != nil {
+		return nil, statusCode, err
+	}
+
+	return &customK8sAction, statusCode, nil
+}
+
+func (c *Client) CreateCustomK8sAction(p *NewCustomK8sAction) (*CustomK8sAction, error) {
+	jsonCustomK8sAction, err := json.Marshal(p)
+	if err != nil {
+		return nil, err
+	}
+
+	res, _, err := c.executeHttpRequest(http.MethodPost, CustomK8sActionUrl, &jsonCustomK8sAction)
+	if err != nil {
+		return nil, err
+	}
+
+	var customK8sAction CustomK8sAction
+	err = json.Unmarshal(res, &customK8sAction)
+	if err != nil {
+		return nil, err
+	}
+
+	return &customK8sAction, nil
+}
+
+func (c *Client) DeleteCustomK8sAction(id string) error {
+	_, _, err := c.executeHttpRequest(http.MethodDelete, fmt.Sprintf(CustomK8sActionUrl+"/%s", id), nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) UpdateCustomK8sAction(id string, p *NewCustomK8sAction) (*CustomK8sAction, error) {
+	jsonCustomK8sAction, err := json.Marshal(p)
+	if err != nil {
+		return nil, err
+	}
+
+	res, _, err := c.executeHttpRequest(http.MethodPut, fmt.Sprintf(CustomK8sActionUrl+"/%s", id), &jsonCustomK8sAction)
+	if err != nil {
+		return nil, err
+	}
+
+	var customK8sAction CustomK8sAction
+	err = json.Unmarshal(res, &customK8sAction)
+	if err != nil {
+		return nil, err
+	}
+
+	return &customK8sAction, nil
+}

--- a/komodor/provider.go
+++ b/komodor/provider.go
@@ -38,6 +38,7 @@ func Provider() *schema.Provider {
 			"komodor_role":                   resourceKomodorRole(),
 			"komodor_policy_role_attachment": resourcePolicyRoleAttachment(),
 			"komodor_monitor":                resourceKomodorMonitor(),
+			"komodor_action":                 resourceKomodorCustomK8sAction(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/komodor/resource_komodor_custom_k8s_action.go
+++ b/komodor/resource_komodor_custom_k8s_action.go
@@ -1,0 +1,138 @@
+package komodor
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceKomodorCustomK8sAction() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"action": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"ruleset": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+		CreateContext: resourceKomodorCustomK8sActionCreate,
+		ReadContext:   resourceKomodorCustomK8sActionRead,
+		UpdateContext: resourceKomodorCustomK8sActionUpdate,
+		DeleteContext: resourceKomodorCustomK8sActionDelete,
+	}
+}
+
+func resourceKomodorCustomK8sActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Client)
+	actionName := d.Get("action").(string)
+	description := d.Get("description").(string)
+	jsonRuleset := d.Get("ruleset")
+
+	var customK8sActionStatements []CustomK8sActionStatement
+	if err := json.Unmarshal([]byte(jsonRuleset.(string)), &customK8sActionStatements); err != nil {
+		return diag.Errorf("Error creating statement structure: %s", err)
+	}
+
+	newCustomK8sAction := &NewCustomK8sAction{
+		Action:      actionName,
+		Description: description,
+		Ruleset:     customK8sActionStatements,
+	}
+
+	customK8sAction, err := client.CreateCustomK8sAction(newCustomK8sAction)
+	if err != nil {
+		return diag.Errorf("Error creating Custom K8S Action: %s, %v", err, customK8sActionStatements)
+	}
+
+	d.SetId(customK8sAction.Id)
+	log.Printf("[INFO] CustomK8sAction created successfully. CustomK8sAction Id: %s", customK8sAction.Id)
+
+	return resourceKomodorCustomK8sActionRead(ctx, d, meta)
+}
+
+func resourceKomodorCustomK8sActionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Client)
+	id := d.Get("action").(string)
+
+	customK8sAction, statusCode, err := client.GetCustomK8sAction(id)
+	if err != nil {
+		if statusCode == 404 {
+			log.Printf("[DEBUG] CustomK8sAction (%s) was not found - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Error reading CustomK8sAction: %s", err)
+	}
+
+	d.Set("action", customK8sAction.Action)
+	d.Set("description", customK8sAction.Description)
+	d.Set("ruleset", customK8sAction.Ruleset)
+	d.Set("created_at", customK8sAction.CreatedAt)
+	d.Set("updated_at", customK8sAction.UpdatedAt)
+
+	return nil
+}
+
+func resourceKomodorCustomK8sActionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Client)
+	id := d.Id()
+	description := d.Get("description").(string)
+	jsonCustomK8sAction := d.Get("ruleset")
+
+	var customK8sActions []CustomK8sActionStatement
+	if err := json.Unmarshal([]byte(jsonCustomK8sAction.(string)), &customK8sActions); err != nil {
+		return diag.Errorf("Error creating statement structure: %s", err)
+	}
+
+	newCustomK8sAction := &NewCustomK8sAction{
+		Action:      d.Get("action").(string),
+		Description: description,
+		Ruleset:     customK8sActions,
+	}
+
+	_, err := client.UpdateCustomK8sAction(id, newCustomK8sAction)
+	if err != nil {
+		return diag.Errorf("Error updating CustomK8sAction: %s", err)
+	}
+
+	log.Printf("[INFO] CustomK8sAction %s successfully updated", id)
+	return resourceKomodorCustomK8sActionRead(ctx, d, meta)
+}
+
+func resourceKomodorCustomK8sActionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Client)
+	id := d.Id()
+
+	log.Printf("[INFO] Deleting CustomK8sAction: %s", id)
+	if err := client.DeleteCustomK8sAction(id); err != nil {
+		return diag.Errorf("Error deleting CustomK8sAction: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}


### PR DESCRIPTION
This PR introduces a `custom action` resource.
The Komodor custom action allows users to configure a Kubernetes ruleset and attach it to a policy. 

Example: 
```tf
resource "komodor_action" "komo-example-pod-viewer" {
  action       = "pod-viewer"
  description = "View pods"
  ruleset = <<EOF
[
  {
    "apiGroups": [
      "apps"
    ],
    "resources": [
      "pods"
    ],
    "verbs": [
      "get",
      "list"
    ]
  }
]
EOF
}
```