### PR TITLE
docs: Update komodor_monitor documentation with schema details and example usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=github.com
 NAMESPACE=komodorio
 NAME=komodor
 BINARY=terraform-provider-${NAME}
-VERSION=1.0.11
+VERSION=2.0.0
 OS_ARCH?=darwin_amd64
 
 default: install

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -40,7 +40,7 @@ Creates a new **Komodor monitor** to observe, detect, and analyze failures acros
 
 #### Valid Configurations:
 - **Valid Sinks**: `slack`, `teams`, `webhook`
-- **Valid notifyOn Options**:
+- **Valid notifyOn Options**: Only one option is valid:
   - `"Failure"`
   - `"Successful"`
   - `"All"`
@@ -67,7 +67,7 @@ EOF
 EOF
   sinks_options = <<EOF
 {
-  "notifyOn": ["Failure", "Successful"]
+  "notifyOn": ["Failure"]
 }
 EOF
 }
@@ -96,7 +96,7 @@ EOF
   - `"Other"`
 - **Valid notifyOn Options**: `["*"]`
   - `["*"]` (all categories)
-  - Or any one of the following:
+  - Or any one of the following: Each notifyOn categories must be included in the "Categories" field
     - `"Creating/Initializing"`
     - `"Scheduling"`
     - `"Container Creation"`
@@ -226,7 +226,7 @@ EOF
 ```terraform
 resource "komodor_monitor" "example-pvc-monitor" {
   name          = "example-pvc-monitor"
-  type          = "pvc"
+  type          = "PVC"
   active        = true
   sensors       = <<EOF
 [{
@@ -251,3 +251,154 @@ EOF
 }
 EOF
 }
+```
+
+---
+
+### CronJob Monitor
+
+#### Valid Configurations:
+- **Valid Sinks**: `slack`, `teams`, `opsgenie`, `pagerduty`, `webhook`
+- **Valid Duration**: Must be an integer between **5** and **600** (inclusive).
+- **Valid CronJobCondition**: `"first"` or `"any"`.
+
+```terraform
+resource "komodor_monitor" "example-cronjob-monitor" {
+  name          = "example-cronjob-monitor"
+  type          = "cronJob"
+  active        = true
+  sensors       = <<EOF
+[{
+  "cluster": "kind-kind",
+  "namespaces": ["jobs-namespace"]
+}]
+EOF
+  sinks         = <<EOF
+{
+  "slack": ["cronjob-alerts"],
+  "teams": ["SRE-Team"],
+  "pagerduty": [{
+    "channel": "example-channel",
+    "integrationKey": "example-integration-key",
+    "pagerDutyAccountName": "example-pagerduty-account-name"
+  }]
+}
+EOF
+  variables     = <<EOF
+{
+  "duration": 120,
+  "cronJobCondition": "first"
+}
+EOF
+}
+```
+
+---
+
+### Job Monitor
+
+#### Valid Configurations:
+- **Valid Sinks**: `slack`, `teams`, `opsgenie`, `pagerduty`, `webhook`
+
+```terraform
+resource "komodor_monitor" "example-job-monitor" {
+  name          = "example-job-monitor"
+  type          = "job"
+  active        = true
+  sensors       = <<EOF
+[{
+  "cluster": "kind-kind",
+  "namespaces": ["job-namespace"]
+}]
+EOF
+  sinks         = <<EOF
+{
+  "slack": ["job-alerts"],
+  "teams": ["SRE-Team"],
+  "pagerduty": [{
+    "channel": "example-channel",
+    "integrationKey": "example-integration-key",
+    "pagerDutyAccountName": "example-pagerduty-account-name"
+  }]
+}
+EOF
+}
+```
+
+---
+
+### Job Monitor
+
+#### Valid Configurations:
+- **Valid Sinks**: `slack`, `teams`, `opsgenie`, `pagerduty`, `webhook`
+- **Valid Duration**: Must be an integer between **5** and **600** (inclusive).
+
+```terraform
+resource "komodor_monitor" "example-job-monitor" {
+  name          = "example-job-monitor"
+  type          = "job"
+  active        = true
+  sensors       = <<EOF
+[{
+  "cluster": "kind-kind",
+  "namespaces": ["job-namespace"]
+}]
+EOF
+  sinks         = <<EOF
+{
+  "slack": ["job-alerts"],
+  "teams": ["SRE-Team"],
+  "pagerduty": [{
+    "channel": "example-channel",
+    "integrationKey": "example-integration-key",
+    "pagerDutyAccountName": "example-pagerduty-account-name"
+  }]
+}
+EOF
+  variables     = <<EOF
+{
+  "duration": 300
+}
+EOF
+}
+```
+
+---
+
+### CronJob Monitor
+
+#### Valid Configurations:
+- **Valid Sinks**: `slack`, `teams`, `opsgenie`, `pagerduty`, `webhook`
+- **Valid Duration**: Must be an integer between **5** and **600** (inclusive).
+- **Valid CronJobCondition**: `"first"` or `"any"`.
+
+```terraform
+resource "komodor_monitor" "example-cronjob-monitor" {
+  name          = "example-cronjob-monitor"
+  type          = "cronJob"
+  active        = true
+  sensors       = <<EOF
+[{
+  "cluster": "kind-kind",
+  "namespaces": ["jobs-namespace"]
+}]
+EOF
+  sinks         = <<EOF
+{
+  "slack": ["cronjob-alerts"],
+  "teams": ["SRE-Team"],
+  "pagerduty": [{
+    "channel": "example-channel",
+    "integrationKey": "example-integration-key",
+    "pagerDutyAccountName": "example-pagerduty-account-name"
+  }]
+}
+EOF
+  variables     = <<EOF
+{
+  "duration": 120,
+  "cronJobCondition": "first"
+}
+EOF
+}
+```

--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -12,6 +12,28 @@ Creates a new **Komodor monitor** to observe, detect, and analyze failures acros
 
 ---
 
+## Schema
+
+### Required
+
+- `active` (Boolean): Indicates whether the monitor is enabled.
+- `name` (String): The name of the monitor. Defaults to an empty string if not provided.
+- `sensors` (String): Defines the scope of monitoring (e.g., cluster, namespaces, services, etc.).
+- `type` (String): The monitor type. Must be one of: `availability`, `node`, `PVC`, `job`, `cronJob`, `deploy`, or `workflow`.
+
+### Optional
+
+- `is_deleted` (Boolean): Default is `false`. Indicates whether the monitor has been marked for deletion.
+- `sinks` (String): Defines notification channels for the monitor, such as Slack, Teams, PagerDuty, Opsgenie, or Webhook.
+- `sinks_options` (String): Specifies additional notification settings like notifyOn. Valid values depend on the monitor type.
+- `variables` (String): Additional settings required for specific monitor types.
+
+### Read-Only
+
+- `id` (String): The ID of this resource.
+
+--
+
 ## Example Usage
 
 ### Deployment Monitor
@@ -192,22 +214,40 @@ EOF
 
 ---
 
-## Schema
+### PVC Monitor
 
-### Required
+#### Valid Configurations:
+- **Valid Sinks**: `slack`, `teams`, `opsgenie`, `pagerduty`, `webhook`
+- **Valid Duration**: Must be an integer between **5** and **600** (inclusive).
+- **Valid NodeCreationThreshold**: Not applicable for PVC.
+- **Valid Categories for variables.categories**: Not applicable for PVC.
+- **Valid notifyOn Options**: Not applicable for PVC.
 
-- `active` (Boolean): Indicates whether the monitor is enabled.
-- `name` (String): The name of the monitor. Defaults to an empty string if not provided.
-- `sensors` (String): Defines the scope of monitoring (e.g., cluster, namespaces, services, etc.).
-- `type` (String): The monitor type. Must be one of: `availability`, `node`, `PVC`, `job`, `cronJob`, `deploy`, or `workflow`.
-
-### Optional
-
-- `is_deleted` (Boolean): Default is `false`. Indicates whether the monitor has been marked for deletion.
-- `sinks` (String): Defines notification channels for the monitor, such as Slack, Teams, PagerDuty, Opsgenie, or Webhook.
-- `sinks_options` (String): Specifies additional notification settings like notifyOn. Valid values depend on the monitor type.
-- `variables` (String): Additional settings required for specific monitor types.
-
-### Read-Only
-
-- `id` (String): The ID of this resource.
+```terraform
+resource "komodor_monitor" "example-pvc-monitor" {
+  name          = "example-pvc-monitor"
+  type          = "pvc"
+  active        = true
+  sensors       = <<EOF
+[{
+  "cluster": "kind-kind",
+  "namespaces": ["storage-namespace"]
+}]
+EOF
+  sinks         = <<EOF
+{
+  "slack": ["storage-alerts"],
+  "teams": ["Storage-Team"],
+  "pagerduty": [{
+    "channel": "example-channel",
+    "integrationKey": "example-integration-key",
+    "pagerDutyAccountName": "example-pagerduty-account-name"
+  }]
+}
+EOF
+  variables     = <<EOF
+{
+  "duration": 300
+}
+EOF
+}

--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     komodor = {
-      version = ">= 1.0.8"
+      version = ">= 2.0.0"
       source  = "komodorio/komodor"
     }
   }

--- a/komodor/monitors.go
+++ b/komodor/monitors.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const MonitorsUrl = DefaultEndpoint + "/monitors/config"
+const MonitorsUrl = V2Endpoint + "/monitors/config"
 
 type (
 	ModelWorkflowConfigurationSensorFilters struct {

--- a/komodor/monitors.go
+++ b/komodor/monitors.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const MonitorsUrl = V2Endpoint + "/monitors/config"
+const MonitorsUrl = V2Endpoint + "/realtime-monitors/config"
 
 type (
 	ModelWorkflowConfigurationSensorFilters struct {
@@ -55,28 +55,28 @@ type (
 )
 
 type NewMonitor struct {
-	Name         string                              `json:"name"`
-	Type         string                              `json:"type"`
-	Active       bool                                `json:"active"`
-	Sensors      []Sensor                            `json:"sensors"`
-	Variables    ModelWorkflowConfigurationVariables `json:"variables,omitempty"`
-	Sinks        Sinks                               `json:"sinks,omitempty"`
-	SinksOptions SinkOptions                         `json:"sinksOptions,omitempty"`
-	IsDeleted    bool                                `json:"isDeleted"`
+	Name         string                               `json:"name"`
+	Type         string                               `json:"type"`
+	Active       bool                                 `json:"active"`
+	Sensors      []Sensor                             `json:"sensors"`
+	Variables    *ModelWorkflowConfigurationVariables `json:"variables,omitempty"`
+	Sinks        *Sinks                               `json:"sinks,omitempty"`
+	SinksOptions *SinkOptions                         `json:"sinksOptions,omitempty"`
+	IsDeleted    bool                                 `json:"isDeleted"`
 }
 
 type Monitor struct {
-	Id          string                              `json:"id"`
-	Name        string                              `json:"name"`
-	Type        string                              `json:"type"`
-	Active      bool                                `json:"active"`
-	Sensors     []Sensor                            `json:"sensors"`
-	Variables   ModelWorkflowConfigurationVariables `json:"variables,omitempty"`
-	Sinks       Sinks                               `json:"sinks,omitempty"`
-	SinkOptions SinkOptions                         `json:"sinkOptions,omitempty"`
-	CreatedAt   string                              `json:"createdAt"`
-	UpdatedAt   string                              `json:"ureatedAt"`
-	IsDeleted   bool                                `json:"isDeleted"`
+	Id          string                               `json:"id"`
+	Name        *string                              `json:"name"`
+	Type        string                               `json:"type"`
+	Active      bool                                 `json:"active"`
+	Sensors     []Sensor                             `json:"sensors"`
+	Variables   *ModelWorkflowConfigurationVariables `json:"variables,omitempty"`
+	Sinks       *Sinks                               `json:"sinks,omitempty"`
+	SinkOptions *SinkOptions                         `json:"sinkOptions,omitempty"`
+	CreatedAt   string                               `json:"createdAt"`
+	UpdatedAt   string                               `json:"updatedAt"`
+	IsDeleted   *bool                                `json:"isDeleted"`
 }
 
 type GetMonitorsData struct {
@@ -100,7 +100,7 @@ func (c *Client) GetMonitors() ([]Monitor, error) {
 		return nil, err
 	}
 
-	return monitors, nil
+	return response.Data.Monitors, nil
 }
 
 func (c *Client) GetMonitor(id string) (*Monitor, int, error) {

--- a/komodor/monitors.go
+++ b/komodor/monitors.go
@@ -79,6 +79,14 @@ type Monitor struct {
 	IsDeleted   bool                                `json:"isDeleted"`
 }
 
+type GetMonitorsData struct {
+	Monitors []Monitor `json:"monitors"`
+}
+
+type GetMonitorsResponse struct {
+	Data GetMonitorsData `json:"data"`
+}
+
 func (c *Client) GetMonitors() ([]Monitor, error) {
 	res, _, err := c.executeHttpRequest(http.MethodGet, MonitorsUrl, nil)
 	if err != nil {

--- a/komodor/provider.go
+++ b/komodor/provider.go
@@ -10,6 +10,7 @@ import (
 )
 
 const DefaultEndpoint = "https://api.komodor.com/mgmt/v1"
+const V2Endpoint = "https://api.komodor.com/api/v2"
 
 // KomodorAPIKeyEnvName name of env var for API key
 const KomodorAPIKeyEnvName = "KOMODOR_API_KEY"

--- a/komodor/resource_komodor_monitor.go
+++ b/komodor/resource_komodor_monitor.go
@@ -85,7 +85,7 @@ func resourceKomodorMonitorCreate(ctx context.Context, d *schema.ResourceData, m
 		if err := json.Unmarshal([]byte(variablesJson.(string)), &variables); err != nil {
 			return diag.Errorf("Error creating variables statement structure: %s", err)
 		}
-		newMonitor.Variables = variables
+		newMonitor.Variables = &variables
 	}
 
 	if sinksJson, sinksJsonExists := d.GetOk("sinks"); sinksJsonExists {
@@ -93,7 +93,7 @@ func resourceKomodorMonitorCreate(ctx context.Context, d *schema.ResourceData, m
 		if err := json.Unmarshal([]byte(sinksJson.(string)), &sinks); err != nil {
 			return diag.Errorf("Error creating sinks statement structure: %s, %s", err, sinksJson)
 		}
-		newMonitor.Sinks = sinks
+		newMonitor.Sinks = &sinks
 	}
 
 	if sinksOptionsJson, sinksOptionsJsonExists := d.GetOk("sinks_options"); sinksOptionsJsonExists {
@@ -101,7 +101,7 @@ func resourceKomodorMonitorCreate(ctx context.Context, d *schema.ResourceData, m
 		if err := json.Unmarshal([]byte(sinksOptionsJson.(string)), &sinksOptions); err != nil {
 			return diag.Errorf("Error creating sinks options statement structure: %s", err)
 		}
-		newMonitor.SinksOptions = sinksOptions
+		newMonitor.SinksOptions = &sinksOptions
 	}
 
 	monitor, err := client.CreateMonitor(newMonitor)
@@ -165,7 +165,7 @@ func resourceKomodorMonitorUpdate(ctx context.Context, d *schema.ResourceData, m
 		if err := json.Unmarshal([]byte(variablesJson.(string)), &variables); err != nil {
 			return diag.Errorf("Error creating variables statement structure: %s", err)
 		}
-		newMonitor.Variables = variables
+		newMonitor.Variables = &variables
 	}
 
 	if sinksJson, sinksJsonExists := d.GetOk("sinks"); sinksJsonExists {
@@ -173,7 +173,7 @@ func resourceKomodorMonitorUpdate(ctx context.Context, d *schema.ResourceData, m
 		if err := json.Unmarshal([]byte(sinksJson.(string)), &sinks); err != nil {
 			return diag.Errorf("Error creating sinks statement structure: %s", err)
 		}
-		newMonitor.Sinks = sinks
+		newMonitor.Sinks = &sinks
 	}
 
 	if sinksOptionsJson, sinksOptionsJsonExists := d.GetOk("sinks_options"); sinksOptionsJsonExists {
@@ -181,7 +181,7 @@ func resourceKomodorMonitorUpdate(ctx context.Context, d *schema.ResourceData, m
 		if err := json.Unmarshal([]byte(sinksOptionsJson.(string)), &sinksOptions); err != nil {
 			return diag.Errorf("Error creating sinks options statement structure: %s", err)
 		}
-		newMonitor.SinksOptions = sinksOptions
+		newMonitor.SinksOptions = &sinksOptions
 	}
 
 	_, err := client.UpdateMonitor(id, newMonitor)


### PR DESCRIPTION
use the monitors v2 version for validation
we will bump a major so we won't break our existing users APIs