### PR TITLE
Cu-86ca0tzr0 docs: cost policies provider ux fixes

### DIFF
--- a/docs/resources/cost_right_sizing_policy.md
+++ b/docs/resources/cost_right_sizing_policy.md
@@ -128,6 +128,13 @@ resource "komodor_cost_right_sizing_policy" "production" {
   priority    = 300
 
   # step 2 - scope
+  #
+  # Multiple `scope` blocks are evaluated with OR semantics: a workload is
+  # in-scope if it matches ANY block. This lets a single policy cover a broad
+  # set AND carve in specific extras that wouldn't be matched by the first.
+
+  # Primary scope — Deployments and StatefulSets in the four service
+  # namespaces across all three prod clusters.
   scope {
     clusters       = ["prod-us-east-1", "prod-eu-west-1", "prod-ap-southeast-2"]
     namespaces     = ["payments", "checkout", "auth", "api"]
@@ -137,6 +144,16 @@ resource "komodor_cost_right_sizing_policy" "production" {
     }
   }
 
+  # Carve-in — the `metrics-collector` DaemonSet in `monitoring-prod`,
+  # which is outside the namespace list above but should be governed by
+  # the same policy.
+  scope {
+    clusters       = ["prod-us-east-1", "prod-eu-west-1", "prod-ap-southeast-2"]
+    namespaces     = ["monitoring-prod"]
+    resource_types = ["DaemonSet"]
+    workload_names = ["metrics-collector"]
+  }
+
   # step 3 - when to apply
   apply_protocol         = "onCreation"
   allow_restart          = true
@@ -144,6 +161,12 @@ resource "komodor_cost_right_sizing_policy" "production" {
 
   # step 4 - guardrails
   optimization_preset = "production"
+
+  # `force_delete = true` lets `terraform destroy` cascade-delete the
+  # workload override records this policy produces. Recommended for any
+  # policy with broad scope or `apply_protocol = "immediate"` — without it,
+  # destroy can return `POLICY_HAS_OVERRIDES` (HTTP 409).
+  force_delete = true
 }
 ```
 
@@ -152,7 +175,7 @@ resource "komodor_cost_right_sizing_policy" "production" {
 
 ### Required
 
-- `apply_protocol` (String) When to apply right-sizing changes. One of: "immediate", "onCreation".
+- `apply_protocol` (String) When to apply right-sizing changes. One of: `immediate`, `onCreation`. **Note:** `immediate` materializes workload override records for every matching workload as soon as the policy is created, independent of `allow_restart`. Destroying such a policy without `force_delete = true` will return `POLICY_HAS_OVERRIDES` (HTTP 409); see `force_delete` for guidance on when to enable it.
 - `name` (String) Unique policy name within the account.
 - `optimization_preset` (String) Optimization preset. "custom" requires an explicit guardrails block; named presets (sandbox/development/staging/production) are resolved to guardrail values server-side and exposed as Computed read-only attributes. Updates to a preset's definition do not affect existing policies.
 - `priority` (Number) Policy evaluation priority. Higher value wins when multiple policies match the same workload.
@@ -163,7 +186,7 @@ resource "komodor_cost_right_sizing_policy" "production" {
 - `allow_hpa_right_sizing` (Boolean) Whether HPA-managed workloads are subject to right-sizing.
 - `allow_restart` (Boolean) Whether Komodor may restart pods to apply right-sizing. Effective only when apply_protocol = "onCreation".
 - `description` (String) Free-text description of the policy.
-- `force_delete` (Boolean) When true, cascade-deletes any active workload overrides on destroy. Has no effect on create/update.
+- `force_delete` (Boolean) When `true`, cascade-deletes any active workload override records on destroy. Has no effect on create/update. **Recommended for any policy intended for `terraform destroy`**, especially when `apply_protocol = "immediate"` or the scope is broad — without it, destroy returns `POLICY_HAS_OVERRIDES` (HTTP 409) whenever override records exist for the policy.
 - `guardrails` (Block List, Max: 1) Right-sizing guardrails. Required when optimization_preset = "custom"; must be omitted otherwise (resolved server-side from the named preset and exposed as Computed). (see [below for nested schema](#nestedblock--guardrails))
 - `tags` (List of String) Optional client-managed tags for categorization. Each tag must be lowercase, start with a letter or digit, and contain only letters, digits, and the characters `_ - : . /`. Max 200 characters per tag; max 19 tags per policy.
 
@@ -180,14 +203,14 @@ resource "komodor_cost_right_sizing_policy" "production" {
 
 Optional:
 
-- `clusters` (List of String) Exact cluster names. The string `"*"` is treated literally — to match all clusters, use `clusters_patterns { include = "*" }` instead. Mutually exclusive with clusters_patterns.
-- `clusters_patterns` (Block List, Max: 1) Glob pattern for cluster names (`include = "*"` matches all). Mutually exclusive with clusters. (see [below for nested schema](#nestedblock--scope--clusters_patterns))
-- `namespaces` (List of String) Exact namespace names. The string `"*"` is treated literally — to match all namespaces, use `namespaces_patterns { include = "*" }` instead. Mutually exclusive with namespaces_patterns.
-- `namespaces_patterns` (Block List, Max: 1) Glob pattern for namespace names (`include = "*"` matches all). Mutually exclusive with namespaces. (see [below for nested schema](#nestedblock--scope--namespaces_patterns))
+- `clusters` (List of String) Required — provide via this field or `clusters_patterns`. Exact cluster names. The string `"*"` is treated literally — to match all clusters, use `clusters_patterns { include = "*" }` instead. Mutually exclusive with clusters_patterns.
+- `clusters_patterns` (Block List, Max: 1) Required — provide via this block or the exact `clusters` list. Glob pattern for cluster names (`include = "*"` matches all). Mutually exclusive with clusters. (see [below for nested schema](#nestedblock--scope--clusters_patterns))
+- `namespaces` (List of String) Required — provide via this field or `namespaces_patterns`. Exact namespace names. The string `"*"` is treated literally — to match all namespaces, use `namespaces_patterns { include = "*" }` instead. Mutually exclusive with namespaces_patterns.
+- `namespaces_patterns` (Block List, Max: 1) Required — provide via this block or the exact `namespaces` list. Glob pattern for namespace names (`include = "*"` matches all). Mutually exclusive with namespaces. (see [below for nested schema](#nestedblock--scope--namespaces_patterns))
 - `resource_types` (List of String) Workload kinds (e.g., Deployment, StatefulSet). The string `"*"` is treated literally — to match all kinds, use `resource_types_patterns { include = "*" }` instead. Mutually exclusive with resource_types_patterns.
 - `resource_types_patterns` (Block List, Max: 1) Glob pattern for workload kinds (`include = "*"` matches all). Mutually exclusive with resource_types. (see [below for nested schema](#nestedblock--scope--resource_types_patterns))
-- `workload_names` (List of String) Exact workload names. The string `"*"` is treated literally — to match all workloads, use `workload_names_patterns { include = "*" }` instead. Mutually exclusive with workload_names_patterns.
-- `workload_names_patterns` (Block List, Max: 1) Glob pattern for workload names (`include = "*"` matches all). Mutually exclusive with workload_names. (see [below for nested schema](#nestedblock--scope--workload_names_patterns))
+- `workload_names` (List of String) Required — provide via this field or `workload_names_patterns`. Exact workload names. The string `"*"` is treated literally — to match all workloads, use `workload_names_patterns { include = "*" }` instead. Mutually exclusive with workload_names_patterns.
+- `workload_names_patterns` (Block List, Max: 1) Required — provide via this block or the exact `workload_names` list. Glob pattern for workload names (`include = "*"` matches all). Mutually exclusive with workload_names. (see [below for nested schema](#nestedblock--scope--workload_names_patterns))
 
 <a id="nestedblock--scope--clusters_patterns"></a>
 ### Nested Schema for `scope.clusters_patterns`

--- a/examples/resources/komodor_cost_right_sizing_policy/resource_production.tf
+++ b/examples/resources/komodor_cost_right_sizing_policy/resource_production.tf
@@ -5,6 +5,13 @@ resource "komodor_cost_right_sizing_policy" "production" {
   priority    = 300
 
   # step 2 - scope
+  #
+  # Multiple `scope` blocks are evaluated with OR semantics: a workload is
+  # in-scope if it matches ANY block. This lets a single policy cover a broad
+  # set AND carve in specific extras that wouldn't be matched by the first.
+
+  # Primary scope — Deployments and StatefulSets in the four service
+  # namespaces across all three prod clusters.
   scope {
     clusters       = ["prod-us-east-1", "prod-eu-west-1", "prod-ap-southeast-2"]
     namespaces     = ["payments", "checkout", "auth", "api"]
@@ -14,6 +21,16 @@ resource "komodor_cost_right_sizing_policy" "production" {
     }
   }
 
+  # Carve-in — the `metrics-collector` DaemonSet in `monitoring-prod`,
+  # which is outside the namespace list above but should be governed by
+  # the same policy.
+  scope {
+    clusters       = ["prod-us-east-1", "prod-eu-west-1", "prod-ap-southeast-2"]
+    namespaces     = ["monitoring-prod"]
+    resource_types = ["DaemonSet"]
+    workload_names = ["metrics-collector"]
+  }
+
   # step 3 - when to apply
   apply_protocol         = "onCreation"
   allow_restart          = true
@@ -21,4 +38,10 @@ resource "komodor_cost_right_sizing_policy" "production" {
 
   # step 4 - guardrails
   optimization_preset = "production"
+
+  # `force_delete = true` lets `terraform destroy` cascade-delete the
+  # workload override records this policy produces. Recommended for any
+  # policy with broad scope or `apply_protocol = "immediate"` — without it,
+  # destroy can return `POLICY_HAS_OVERRIDES` (HTTP 409).
+  force_delete = true
 }

--- a/komodor/cost_right_sizing_policies_validate.go
+++ b/komodor/cost_right_sizing_policies_validate.go
@@ -177,6 +177,19 @@ func userProvidedGuardRails(d *schema.ResourceDiff) bool {
 	return gr.LengthInt() > 0
 }
 
+func warnLiteralStarInExactList(v interface{}, p cty.Path) diag.Diagnostics {
+	s, ok := v.(string)
+	if !ok || s != "*" {
+		return nil
+	}
+	return diag.Diagnostics{{
+		Severity:      diag.Warning,
+		Summary:       `"*" in an exact-match scope list is literal, not a wildcard`,
+		Detail:        `To match all items, use the corresponding *_patterns block with include = "*" instead. The literal "*" matches only an entity whose name is the single character "*", which is almost never intended.`,
+		AttributePath: p,
+	}}
+}
+
 func validateUnsupportedString(field string, allowed []string) schema.SchemaValidateDiagFunc {
 	return func(v interface{}, _ cty.Path) diag.Diagnostics {
 		val, ok := v.(string)

--- a/komodor/cost_right_sizing_policies_validate_test.go
+++ b/komodor/cost_right_sizing_policies_validate_test.go
@@ -3,8 +3,37 @@ package komodor
 import (
 	"testing"
 
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestWarnLiteralStarInExactList(t *testing.T) {
+	path := cty.GetAttrPath("clusters").IndexInt(0)
+
+	tests := []struct {
+		name      string
+		input     interface{}
+		wantDiags int
+	}{
+		{name: "literal star emits warning", input: "*", wantDiags: 1},
+		{name: "normal value emits nothing", input: "prod-cluster", wantDiags: 0},
+		{name: "empty string emits nothing", input: "", wantDiags: 0},
+		{name: "non-string input emits nothing", input: 42, wantDiags: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diags := warnLiteralStarInExactList(tc.input, path)
+			assert.Len(t, diags, tc.wantDiags)
+			if tc.wantDiags > 0 {
+				assert.Equal(t, diag.Warning, diags[0].Severity, "must be a Warning, never an Error")
+				assert.Equal(t, path, diags[0].AttributePath, "diagnostic must be anchored to the attribute path")
+				assert.Contains(t, diags[0].Detail, `*_patterns`, "detail should suggest the *_patterns alternative")
+			}
+		})
+	}
+}
 
 func TestValidateScopeDimension_MutualExclusion(t *testing.T) {
 	itemsList := []interface{}{"foo", "bar"}

--- a/komodor/cost_right_sizing_policies_validate_test.go
+++ b/komodor/cost_right_sizing_policies_validate_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,6 +32,36 @@ func TestWarnLiteralStarInExactList(t *testing.T) {
 				assert.Equal(t, path, diags[0].AttributePath, "diagnostic must be anchored to the attribute path")
 				assert.Contains(t, diags[0].Detail, `*_patterns`, "detail should suggest the *_patterns alternative")
 			}
+		})
+	}
+}
+
+func TestScopeStringFields_WireLiteralStarWarning(t *testing.T) {
+	scopeRes := costRSPScopeResource()
+	fields := []string{"clusters", "namespaces", "resource_types", "workload_names"}
+
+	for _, field := range fields {
+		t.Run(field, func(t *testing.T) {
+			fieldSchema, ok := scopeRes.Schema[field]
+			if !assert.True(t, ok, "scope schema must define %q", field) {
+				return
+			}
+			elem, ok := fieldSchema.Elem.(*schema.Schema)
+			if !assert.True(t, ok, "field %q must use *schema.Schema as Elem", field) {
+				return
+			}
+			if !assert.NotNil(t, elem.ValidateDiagFunc, "field %q must wire ValidateDiagFunc on its element", field) {
+				return
+			}
+			path := cty.GetAttrPath(field).IndexInt(0)
+
+			warn := elem.ValidateDiagFunc("*", path)
+			if assert.Len(t, warn, 1, "field %q must warn on literal *", field) {
+				assert.Equal(t, diag.Warning, warn[0].Severity)
+			}
+
+			none := elem.ValidateDiagFunc("real-name", path)
+			assert.Empty(t, none, "field %q must not warn on a normal value", field)
 		})
 	}
 }

--- a/komodor/resource_komodor_cost_right_sizing_policy.go
+++ b/komodor/resource_komodor_cost_right_sizing_policy.go
@@ -80,7 +80,7 @@ func resourceKomodorCostRightSizingPolicy() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateDiagFunc: validateUnsupportedString("apply_protocol", applyProtocols),
-				Description:      `When to apply right-sizing changes. One of: "immediate", "onCreation".`,
+				Description:      "When to apply right-sizing changes. One of: `immediate`, `onCreation`. **Note:** `immediate` materializes workload override records for every matching workload as soon as the policy is created, independent of `allow_restart`. Destroying such a policy without `force_delete = true` will return `POLICY_HAS_OVERRIDES` (HTTP 409); see `force_delete` for guidance on when to enable it.",
 			},
 			"allow_restart": {
 				Type:        schema.TypeBool,
@@ -129,7 +129,7 @@ func resourceKomodorCostRightSizingPolicy() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "When true, cascade-deletes any active workload overrides on destroy. Has no effect on create/update.",
+				Description: "When `true`, cascade-deletes any active workload override records on destroy. Has no effect on create/update. **Recommended for any policy intended for `terraform destroy`**, especially when `apply_protocol = \"immediate\"` or the scope is broad — without it, destroy returns `POLICY_HAS_OVERRIDES` (HTTP 409) whenever override records exist for the policy.",
 			},
 
 			"id": {
@@ -164,9 +164,12 @@ func resourceKomodorCostRightSizingPolicy() *schema.Resource {
 func costRSPScopeResource() *schema.Resource {
 	stringList := func(desc string) *schema.Schema {
 		return &schema.Schema{
-			Type:        schema.TypeList,
-			Optional:    true,
-			Elem:        &schema.Schema{Type: schema.TypeString},
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type:             schema.TypeString,
+				ValidateDiagFunc: warnLiteralStarInExactList,
+			},
 			Description: desc,
 		}
 	}
@@ -181,14 +184,14 @@ func costRSPScopeResource() *schema.Resource {
 	}
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"clusters":                stringList("Exact cluster names. The string `\"*\"` is treated literally — to match all clusters, use `clusters_patterns { include = \"*\" }` instead. Mutually exclusive with clusters_patterns."),
-			"clusters_patterns":       patternBlock("Glob pattern for cluster names (`include = \"*\"` matches all). Mutually exclusive with clusters."),
-			"namespaces":              stringList("Exact namespace names. The string `\"*\"` is treated literally — to match all namespaces, use `namespaces_patterns { include = \"*\" }` instead. Mutually exclusive with namespaces_patterns."),
-			"namespaces_patterns":     patternBlock("Glob pattern for namespace names (`include = \"*\"` matches all). Mutually exclusive with namespaces."),
+			"clusters":                stringList("Required — provide via this field or `clusters_patterns`. Exact cluster names. The string `\"*\"` is treated literally — to match all clusters, use `clusters_patterns { include = \"*\" }` instead. Mutually exclusive with clusters_patterns."),
+			"clusters_patterns":       patternBlock("Required — provide via this block or the exact `clusters` list. Glob pattern for cluster names (`include = \"*\"` matches all). Mutually exclusive with clusters."),
+			"namespaces":              stringList("Required — provide via this field or `namespaces_patterns`. Exact namespace names. The string `\"*\"` is treated literally — to match all namespaces, use `namespaces_patterns { include = \"*\" }` instead. Mutually exclusive with namespaces_patterns."),
+			"namespaces_patterns":     patternBlock("Required — provide via this block or the exact `namespaces` list. Glob pattern for namespace names (`include = \"*\"` matches all). Mutually exclusive with namespaces."),
 			"resource_types":          stringList("Workload kinds (e.g., Deployment, StatefulSet). The string `\"*\"` is treated literally — to match all kinds, use `resource_types_patterns { include = \"*\" }` instead. Mutually exclusive with resource_types_patterns."),
 			"resource_types_patterns": patternBlock("Glob pattern for workload kinds (`include = \"*\"` matches all). Mutually exclusive with resource_types."),
-			"workload_names":          stringList("Exact workload names. The string `\"*\"` is treated literally — to match all workloads, use `workload_names_patterns { include = \"*\" }` instead. Mutually exclusive with workload_names_patterns."),
-			"workload_names_patterns": patternBlock("Glob pattern for workload names (`include = \"*\"` matches all). Mutually exclusive with workload_names."),
+			"workload_names":          stringList("Required — provide via this field or `workload_names_patterns`. Exact workload names. The string `\"*\"` is treated literally — to match all workloads, use `workload_names_patterns { include = \"*\" }` instead. Mutually exclusive with workload_names_patterns."),
+			"workload_names_patterns": patternBlock("Required — provide via this block or the exact `workload_names` list. Glob pattern for workload names (`include = \"*\"` matches all). Mutually exclusive with workload_names."),
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Enhance the `komodor_cost_right_sizing_policy` documentation and surface a few UX gaps the PM hit while testing v3.2.0.

## What's new

- Three scope dimensions (`clusters`, `namespaces`, `workload_names`) and their `*_patterns` counterparts are now declared Required in field descriptions — matches the validator.
- `apply_protocol` and `force_delete` descriptions explain the `apply_protocol = "immediate"` → `POLICY_HAS_OVERRIDES` failure mode on destroy.
- Plan-time `diag.Warning` when an exact-match scope list contains the literal string `"*"` (which silently matches nothing); points users at `*_patterns { include = "*" }`. Non-blocking, anchored to the offending attribute.
- Multi-scope example in `resource_production.tf` with a carve-in second scope and `force_delete = true` to model the destroy-safe pattern.
- Registry docs regenerated.

## Notes

- Schema-level acceptance test that `resource_types = ["*"]` triggers the warning is deferred as a follow-up; the unit test covers the function but not the schema wiring.
- Multi-scope design (repeated `scope {}` blocks vs. list-of-objects) reviewed and confirmed — nested `*_patterns` sub-blocks can't be expressed cleanly in SDKv2 list-of-objects.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test -run TestWarnLiteralStarInExactList -v ./komodor/...` — 4 subtests pass
- [x] Existing `TestValidate*` / `TestExpand*` suites green
- [x] `make generate-docs` clean; doc diff matches the schema description changes
- [ ] Follow-up: schema-level acceptance test for `resource_types = ["*"]` warning

Refs: CU-86ca0tzr0